### PR TITLE
Forward-port credentials fetch argument from mark/credential-support to main

### DIFF
--- a/addon/mixins/fetch-request.js
+++ b/addon/mixins/fetch-request.js
@@ -74,6 +74,7 @@ export default Mixin.create({
       headers: {
         ...(hash.headers || {}),
       },
+      credentials: get(this, 'credentials') || undefined,
     };
 
     const abortController = new AbortController();


### PR DESCRIPTION
## Purpose

Forward-port the `credentials` fetch-argument feature from commit `0b6afaa` on the `mark/credential-support` branch onto `main`.

## Why

The betterup-monolith currently pins this addon to `bd96c86` on `mark/credential-support` because that branch contains the load-bearing change `0b6afaa` ("Expose credentials fetch argument as class property"). Pinning to a non-default branch is also the root cause of [BUAPP-114397](https://betterup.atlassian.net/browse/BUAPP-114397): the `packageManager: yarn@1.22.22` field on `mark/credential-support` makes Yarn Berry bootstrap Yarn Classic to install this dep, and concurrent bootstraps for git-source deps race on `/usr/local/share/.cache/yarn/v6/`.

Once this PR merges, the monolith can re-pin to `main` HEAD and stop bootstrapping yarn-classic for this dep.

## Approach

Attempted `git cherry-pick 0b6afaa`. The auto-merge conflicted because `main` includes commit `194ebb5` ("Remove deprecated EmberError and assign") which reformatted `addon/mixins/fetch-request.js` (trailing-comma style, etc.) — semantically unrelated to the credentials feature. Resolution was mechanical: applied the single-line addition (`credentials: get(this, 'credentials') || undefined,`) inside the `requestOptions` object on `main`'s post-refactor file. `get` was already imported on `main`. Original authorship attributed to Mark Philpot.

## AI Tools Used

Claude Code

## Testing

The semantic diff vs. `mark/credential-support` is identical to commit `0b6afaa`. That branch has been in production via the monolith for ~16 months without issue. The monolith's BUAPP-114397 PR will validate end-to-end behavior once it bumps to this commit.
